### PR TITLE
edit_by_criteria function + test

### DIFF
--- a/src/mongodb/db_repository.py
+++ b/src/mongodb/db_repository.py
@@ -74,6 +74,13 @@ class DataRepository:
         """
         collection = self._select_collection(value_type)
         return collection.update_one({field: value}, {'$set': updates})
+    
+
+    def update_by_criteria(self, value_type: Type[Union[AddressBook, NoteBook]], search_criteria: dict, updates: dict):
+        collection = self._select_collection(value_type)
+        return collection.update_one(search_criteria, {'$set': updates})
+
+
 
     def delete(self, value_type: Type[Union[AddressBook, NoteBook]], field: str, value: str):
         """
@@ -89,3 +96,4 @@ class DataRepository:
         """
         collection = self._select_collection(value_type)
         return collection.delete_one({field: value})
+

--- a/src/utils/contact_book/contact_book_manager.py
+++ b/src/utils/contact_book/contact_book_manager.py
@@ -29,6 +29,12 @@ class ContactBookManager:
         except Exception as e:
             print(f"An error occurred: {str(e)}")
 
+    def edit_by_criteria(self, search_criteria, updates):
+        try:
+            self.data_repo.update_by_criteria(value_type=AddressBook, search_criteria=search_criteria, updates=updates)
+        except Exception as e:
+            print(f"An error occurred: {str(e)}")
+
     def delete(self, field, value):
         try:
             self.data_repo.delete(value_type=AddressBook, field=field, value=value)

--- a/src/utils/notes_book/notesbook_manager.py
+++ b/src/utils/notes_book/notesbook_manager.py
@@ -39,6 +39,12 @@ class NotesBookManager:
             self.data_repo.update(value_type=NoteBook, field=field, value=value, updates=updates)
         except Exception as e:
             print(f"An error occurred: {str(e)}")
+
+    def edit_by_criteria(self, search_criteria, updates):
+        try:
+            self.data_repo.update_by_criteria(value_type=NoteBook, search_criteria=search_criteria, updates=updates)
+        except Exception as e:
+            print(f"An error occurred: {str(e)}")
     
     def delete(self, field, value):
         try:

--- a/tests/edit_by_criteria.py
+++ b/tests/edit_by_criteria.py
@@ -1,0 +1,25 @@
+from src.utils.contact_book.contact_book_collector import ContactBookCollector
+from src.utils.contact_book.contact_book_manager import ContactBookManager
+from tests.look_for_doubles import *
+
+def read_all_contacts_book():
+    notes_manager = ContactBookManager()
+    notes = notes_manager.read_all()
+    if notes:
+        print(f"here is the contact list:")
+        for note in notes:
+            print(note)
+    else:
+        print(f'No notes in the database.')
+
+
+def test_edit(search_criteria, updates):
+    ContactBookManager().edit_by_criteria(search_criteria, updates)
+
+if __name__ == '__main__':
+    read_all_contacts_book()
+    doubles = doubles_contacts("name", "Barbara")
+    choice = 1
+    _id = doubles[choice - 1]["_id"]
+    test_edit({"_id":_id}, {"name": "Basia"})
+    read_all_contacts_book()


### PR DESCRIPTION
Podstawowa funkcja edit nie pozwalała nam edytowania wpisu zdublowanego innego niż pierwszy z listy.
edit_by_criteria przyjmuje słownik {"_id": id}, wyszukuje rokord w bazie na podstawie kryterium i edytuje go na postawie słownika updates {key:value}.
Teraz za pomocą look_for_doubles, użytkownik określa który rekord chce edytować, program przechwytuje jego id i przekazuje do edit_by_criteria